### PR TITLE
Do not auto-create colour classes

### DIFF
--- a/_palette.scss
+++ b/_palette.scss
@@ -1,5 +1,3 @@
-@import "../guss-colours/_colours";
-
 /**
  * Default colour palette
  *

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,5 @@
   "main": [
     "_palette.scss"
   ],
-  "dependencies": {
-    "guss-colours": "~3.0.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
The ability to generate colour classes from a sass list is a feature of guss-colours. If you want them you can generate them using it, but you shouldn't be forced to ship them whenever you use pasteup-palette.

This removes all dependency on guss-colours, so it's also removed.
